### PR TITLE
Allow multiple alternative domain names

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ To generate a certificate for `example.dev` and its subdomains, run:
 create-certificate.sh example.dev
 ```
 
+To generate a certificate for `example.dev` along with one or more [alternative domains](https://en.wikipedia.org/wiki/Subject_Alternative_Name), run:
+
+```
+create-certificate.sh example.dev alternative-domain.dev alternative-domain.test
+```
+
 ![create-certificate.sh](https://raw.githubusercontent.com/BenMorel/dev-certificates/main/images/create-certificate.png)
 
 You can now install the `.key` and `.crt` files in your web server, such as Apache or Nginx.


### PR DESCRIPTION
Some projects have functionality based upon multiple domain names, not being sub-domain of the "main domain". In that case it's useful to have one certificate that allows adding those "alternative" domain names.